### PR TITLE
feat: Allow overriding metadata when deploying to s3

### DIFF
--- a/lib/deploy-methods/s3.js
+++ b/lib/deploy-methods/s3.js
@@ -11,7 +11,7 @@ function _updateProgress(reporter, message) {
     }
 }
 
-function _doRelease(build, target, algorithm, reporter) {
+function _doRelease(build, target, algorithm, fileOptions, reporter) {
     return new Promise((resolve, reject) => {
         const bucketMap = {};
         const extract = tarStream.extract();
@@ -52,6 +52,11 @@ function _doRelease(build, target, algorithm, reporter) {
                         _updateProgress(reporter, `Uploading ${header.name}`);
                     }
 
+                    let contentType = mime.lookup(header.name) || 'application/octet-stream';
+                    if (fileOptions[header.name] && fileOptions[header.name].ContentType) {
+                        contentType = fileOptions[header.name].ContentType;
+                    }
+
                     s3.getInstance().upload(
                         {
                             Bucket: target,
@@ -59,7 +64,7 @@ function _doRelease(build, target, algorithm, reporter) {
                             Body: stream,
                             ACL: 'public-read',
                             CacheControl: 'max-age=600',
-                            ContentType: mime.lookup(header.name) || 'application/octet-stream',
+                            ContentType: contentType,
                         },
                         (err) => {
                             if (err) {
@@ -144,18 +149,19 @@ function _downloadKartFile(project, channel) {
  *   * overwrite: Writes all the files into the bucked without clearing it out first.
  *   * sync:      Uses the `aws sync` command to minimise bandwith usage.
  *
- * @param {Object} build           The build object to be released.
- * @param {Object} opts            Options.
- * @param {String} opts.bucket     Name of the bucket to deploy to.
- * @param {String} opts.algorithm  Either 'clear', 'overwrite' or 'sync'.
- * @param {String} opts.reporter   An optional event listener to report events.
+ * @param {Object} build             The build object to be released.
+ * @param {Object} opts              Options.
+ * @param {String} opts.bucket       Name of the bucket to deploy to.
+ * @param {String} opts.algorithm    Either 'clear', 'overwrite' or 'sync'.
+ * @param {Object} opts.fileOptions  Per-file options that will be applied when uploading to S3 (metadata, etc).
+ * @param {String} opts.reporter     An optional event listener to report events.
  */
 function release(build, opts) {
-    const { bucket, algorithm = 'clear' } = opts;
+    const { bucket, algorithm = 'clear', fileOptions = {} } = opts;
     let releaseObject;
 
     return build.fetchMetadata()
-        .then(() => (algorithm === 'clear' ? s3.clearBucket(bucket) : Promise.resolve())).then(() => _doRelease(build, bucket, algorithm, opts.reporter)).then((r) => {
+        .then(() => (algorithm === 'clear' ? s3.clearBucket(bucket) : Promise.resolve())).then(() => _doRelease(build, bucket, algorithm, fileOptions, opts.reporter)).then((r) => {
             releaseObject = r;
             return _uploadKartFile(releaseObject, bucket);
         })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kart",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Kano Archive and Release Tool. Managing releases mainly of static websites.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Sometimes, the ContentType detection fails for certain files when uploading. This adds the option to set metadata in project config.